### PR TITLE
Introduce Button + Notification to Enable/Disable heap dump

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -21,6 +21,7 @@ import leakcanary.internal.RetainInstanceEvent.CountChanged.DebuggerIsAttached
 import leakcanary.internal.RetainInstanceEvent.CountChanged.DumpHappenedRecently
 import leakcanary.internal.RetainInstanceEvent.CountChanged.BelowThreshold
 import leakcanary.internal.RetainInstanceEvent.NoMoreObjects
+import leakcanary.internal.activity.screen.AboutScreen
 import shark.AndroidResourceIdNames
 import shark.SharkLog
 
@@ -53,6 +54,10 @@ internal class HeapDumpTrigger(
 
   private val scheduleDismissNoRetainedOnTapNotification = {
     dismissNoRetainedOnTapNotification()
+  }
+
+  private val scheduleDismissHeapDumpDisabledNotification = {
+    dismissHeapDumpDisabledNotification()
   }
 
   /**
@@ -95,7 +100,19 @@ internal class HeapDumpTrigger(
     val config = configProvider()
     // A tick will be rescheduled when this is turned back on.
     if (!config.dumpHeap) {
-      SharkLog.d { "Ignoring check for retained objects scheduled because $reason: LeakCanary.Config.dumpHeap is false" }
+      val resources = application.resources
+      val heapDumpStatus = AboutScreen.getHeapDumpStatus(resources = resources)
+      val message = when(heapDumpStatus) {
+        AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_UI -> "Heap Dump is disabled from the About Screen"
+        else -> "LeakCanary.Config.dumpHeap is false"
+      }
+
+      SharkLog.d { "Ignoring check for retained objects scheduled because $reason: $message" }
+
+      if (heapDumpStatus == AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_UI) {
+        showHeapDumpDisabledNotification()
+
+      }
       return
     }
 
@@ -338,6 +355,29 @@ internal class HeapDumpTrigger(
     notificationManager.notify(R.id.leak_canary_notification_retained_objects, notification)
   }
 
+  private fun showHeapDumpDisabledNotification() {
+    backgroundHandler.removeCallbacks(scheduleDismissHeapDumpDisabledNotification)
+    if (!Notifications.canShowNotification) {
+      return
+    }
+    @Suppress("DEPRECATION")
+    val builder = Notification.Builder(application)
+        .setContentTitle(
+            application.getString(R.string.leak_canary_notification_heap_dump_disabled)
+        )
+        .setContentText(
+            application.getString(
+                R.string.leak_canary_notification_no_retained_object_content
+            )
+        )
+        .setAutoCancel(true)
+        // TODO: Add Action to open About Screen
+        .setContentIntent(NotificationReceiver.pendingIntent(application, CANCEL_NOTIFICATION))
+    val notification =
+        Notifications.buildNotification(application, builder, LEAKCANARY_LOW)
+    notificationManager.notify(R.id.leak_canary_notification_heap_dump_disabled, notification)
+  }
+
   private fun dismissRetainedCountNotification() {
     backgroundHandler.removeCallbacks(scheduleDismissRetainedCountNotification)
     notificationManager.cancel(R.id.leak_canary_notification_retained_objects)
@@ -346,6 +386,11 @@ internal class HeapDumpTrigger(
   private fun dismissNoRetainedOnTapNotification() {
     backgroundHandler.removeCallbacks(scheduleDismissNoRetainedOnTapNotification)
     notificationManager.cancel(R.id.leak_canary_notification_no_retained_object_on_tap)
+  }
+
+  private fun dismissHeapDumpDisabledNotification() {
+    backgroundHandler.removeCallbacks(scheduleDismissRetainedCountNotification)
+    notificationManager.cancel(R.id.leak_canary_notification_retained_objects)
   }
 
   companion object {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -111,7 +111,6 @@ internal class HeapDumpTrigger(
 
       if (heapDumpStatus == AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_ABOUT_SCREEN) {
         showHeapDumpDisabledNotification()
-
       }
       return
     }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -103,13 +103,13 @@ internal class HeapDumpTrigger(
       val resources = application.resources
       val heapDumpStatus = AboutScreen.getHeapDumpStatus(resources = resources)
       val message = when(heapDumpStatus) {
-        AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_UI -> "Heap Dump is disabled from the About Screen"
+        AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_ABOUT_SCREEN -> "Heap Dump is disabled from the About Screen"
         else -> "LeakCanary.Config.dumpHeap is false"
       }
 
       SharkLog.d { "Ignoring check for retained objects scheduled because $reason: $message" }
 
-      if (heapDumpStatus == AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_UI) {
+      if (heapDumpStatus == AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_ABOUT_SCREEN) {
         showHeapDumpDisabledNotification()
 
       }
@@ -367,13 +367,12 @@ internal class HeapDumpTrigger(
         )
         .setContentText(
             application.getString(
-                R.string.leak_canary_notification_no_retained_object_content
+                R.string.leak_canary_notification_heap_dump_tap_to_dismiss
             )
         )
         .setAutoCancel(true)
         .setContentIntent(NotificationReceiver.pendingIntent(application, CANCEL_NOTIFICATION))
-    val notification =
-        Notifications.buildNotification(application, builder, LEAKCANARY_LOW)
+    val notification = Notifications.buildNotification(application, builder, LEAKCANARY_LOW)
     notificationManager.notify(R.id.leak_canary_notification_heap_dump_disabled, notification)
   }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -371,7 +371,6 @@ internal class HeapDumpTrigger(
             )
         )
         .setAutoCancel(true)
-        // TODO: Add Action to open About Screen
         .setContentIntent(NotificationReceiver.pendingIntent(application, CANCEL_NOTIFICATION))
     val notification =
         Notifications.buildNotification(application, builder, LEAKCANARY_LOW)

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
@@ -64,6 +64,7 @@ internal class AboutScreen : Screen() {
       ENABLED,
       DISABLED_DEBUGGER_ATTACHED,
       DISABLED_BY_DEVELOPER,
+      DISABLED_FROM_UI,
       DISABLED_RUNNING_TESTS,
       NOT_INSTALLED
     }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
@@ -13,7 +13,7 @@ import leakcanary.LeakCanary
 import leakcanary.internal.DebuggerControl
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_BY_DEVELOPER
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_DEBUGGER_ATTACHED
-import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_UI
+import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_ABOUT_SCREEN
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_RUNNING_TESTS
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.ENABLED
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.NOT_INSTALLED
@@ -65,7 +65,7 @@ internal class AboutScreen : Screen() {
           resources.getString(R.string.leak_canary_heap_dump_disabled_text),
           resources.getString(R.string.leak_canary_heap_dump_disabled_by_app)
       )
-      DISABLED_FROM_UI -> String.format(
+      DISABLED_FROM_ABOUT_SCREEN -> String.format(
             resources.getString(R.string.leak_canary_heap_dump_disabled_text),
             resources.getString(R.string.leak_canary_heap_dump_disabled_from_ui)
         )
@@ -87,7 +87,7 @@ internal class AboutScreen : Screen() {
       ENABLED,
       DISABLED_DEBUGGER_ATTACHED,
       DISABLED_BY_DEVELOPER,
-      DISABLED_FROM_UI,
+      DISABLED_FROM_ABOUT_SCREEN,
       DISABLED_RUNNING_TESTS,
       NOT_INSTALLED
     }
@@ -100,7 +100,7 @@ internal class AboutScreen : Screen() {
           if (isRunningTests(resources)) {
             DISABLED_RUNNING_TESTS
           } else if (!heapDumpSwitchChecked) {
-              DISABLED_FROM_UI
+              DISABLED_FROM_ABOUT_SCREEN
           } else {
             DISABLED_BY_DEVELOPER
           }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import android.text.Html
 import android.text.method.LinkMovementMethod
 import android.view.ViewGroup
+import android.widget.Switch
 import android.widget.TextView
 import com.squareup.leakcanary.core.BuildConfig
 import com.squareup.leakcanary.core.R
@@ -12,6 +13,7 @@ import leakcanary.LeakCanary
 import leakcanary.internal.DebuggerControl
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_BY_DEVELOPER
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_DEBUGGER_ATTACHED
+import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_FROM_UI
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_RUNNING_TESTS
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.ENABLED
 import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.NOT_INSTALLED
@@ -19,7 +21,10 @@ import leakcanary.internal.navigation.Screen
 import leakcanary.internal.navigation.activity
 import leakcanary.internal.navigation.inflate
 
+private var heapDumpSwitchChecked = true
+
 internal class AboutScreen : Screen() {
+
   override fun createView(container: ViewGroup) =
     container.inflate(R.layout.leak_canary_about_screen)
         .apply {
@@ -39,6 +44,13 @@ internal class AboutScreen : Screen() {
 
           val heapDumpText = findViewById<TextView>(R.id.leak_canary_about_heap_dump_text)
           heapDumpText.text = getHeapDumpStatusMessage(resources)
+          val heapDumpSwitchView = findViewById<Switch>(R.id.leak_canary_about_heap_dump_switch_button)
+          heapDumpSwitchView.isChecked = heapDumpSwitchChecked
+          heapDumpSwitchView.setOnCheckedChangeListener { _, isChecked ->
+              heapDumpSwitchChecked = isChecked
+              updateConfig()
+              heapDumpText.text = getHeapDumpStatusMessage(resources)
+           }
         }
 
   private fun getHeapDumpStatusMessage(resources: Resources) =
@@ -53,13 +65,24 @@ internal class AboutScreen : Screen() {
           resources.getString(R.string.leak_canary_heap_dump_disabled_text),
           resources.getString(R.string.leak_canary_heap_dump_disabled_by_app)
       )
+      DISABLED_FROM_UI -> String.format(
+            resources.getString(R.string.leak_canary_heap_dump_disabled_text),
+            resources.getString(R.string.leak_canary_heap_dump_disabled_from_ui)
+        )
       DISABLED_RUNNING_TESTS -> String.format(
           resources.getString(R.string.leak_canary_heap_dump_disabled_text),
           resources.getString(R.string.leak_canary_heap_dump_disabled_running_tests)
       )
     }
 
-  private companion object HeapDumpPolicy {
+    /**
+     * Updates leak canary config to enable/disable heap dump depending upon the Toggle switch from the about screen.
+     */
+    private fun updateConfig() {
+        LeakCanary.config = LeakCanary.config.copy(dumpHeap = heapDumpSwitchChecked)
+    }
+
+    private companion object HeapDumpPolicy {
     enum class HeapDumpStatus {
       ENABLED,
       DISABLED_DEBUGGER_ATTACHED,
@@ -76,6 +99,8 @@ internal class AboutScreen : Screen() {
         !config.dumpHeap ->
           if (isRunningTests(resources)) {
             DISABLED_RUNNING_TESTS
+          } else if (!heapDumpSwitchChecked) {
+              DISABLED_FROM_UI
           } else {
             DISABLED_BY_DEVELOPER
           }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
@@ -82,7 +82,7 @@ internal class AboutScreen : Screen() {
         LeakCanary.config = LeakCanary.config.copy(dumpHeap = heapDumpSwitchChecked)
     }
 
-    private companion object HeapDumpPolicy {
+    companion object HeapDumpPolicy {
     enum class HeapDumpStatus {
       ENABLED,
       DISABLED_DEBUGGER_ATTACHED,

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_about_screen.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_about_screen.xml
@@ -12,6 +12,19 @@
       android:paddingRight="16dp"
       />
 
+  <Switch
+      android:id="@+id/leak_canary_about_heap_dump_switch_button"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_above="@+id/leak_canary_about_heap_dump_text"
+      android:paddingBottom="16dp"
+      android:paddingLeft="16dp"
+      android:checked="true"
+      android:text="@string/leak_canary_about_enable_heap_dump"
+      android:textOn="@string/leak_canary_about_enable_heap_dump_textOn"
+      android:textOff="@string/leak_canary_about_enable_heap_dump_textOff"
+      />
+
   <TextView
       android:id="@+id/leak_canary_about_heap_dump_text"
       android:layout_width="match_parent"

--- a/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
@@ -22,4 +22,5 @@
   <item type="id" name="leak_canary_notification_retained_objects" />
   <item type="id" name="leak_canary_notification_no_retained_object_on_tap" />
   <item type="id" name="leak_canary_notification_on_screen_exit" />
+  <item type="id" name="leak_canary_notification_heap_dump_disabled" />
 </resources>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -25,10 +25,14 @@
   We welcome contributions from the community - please do not hesitate to
   <a href="https://github.com/square/leakcanary/issues">report an issue</a> or open a pull request!<br><br>
 ]]></string>
+  <string name="leak_canary_about_enable_heap_dump">Enable Heap Dump</string>
+  <string name="leak_canary_about_enable_heap_dump_textOn">Enable</string>
+  <string name="leak_canary_about_enable_heap_dump_textOff">Disable</string>
   <string name="leak_canary_heap_dump_disabled_text">Heap dumping is currently disabled, because <i>%s</i>.</string>
   <string name="leak_canary_heap_dump_not_installed_text">AppWatcher is not installed.</string>
   <string name="leak_canary_heap_dump_enabled_text">Heap dumping is currently enabled.</string>
   <string name="leak_canary_heap_dump_disabled_by_app">LeakCanary.Config.dumpHeap is set to false</string>
+  <string name="leak_canary_heap_dump_disabled_from_ui">Heap dump is disabled from UI</string>
   <string name="leak_canary_heap_dump_disabled_running_tests">tests are running</string>
   <string name="leak_canary_heap_dump_disabled_build_non_debuggable">the debugger is attached and LeakCanary.Config.dumpHeapWhenDebugging is set to false</string>
   <string name="leak_canary_analysis_failed">Heap analysis failed</string>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -57,7 +57,7 @@
   <string name="leak_canary_notification_retained_dump_failed">Failed to dump heap</string>
   <string name="leak_canary_notification_retained_dump_wait">Last heap dump was less than a minute ago</string>
   <string name="leak_canary_notification_retained_title">%d retained objects, tap to dump heap</string>
-  <string name="leak_canary_notification_heap_dump_disabled">Heap Dump is disabled from About Screen</string>
+  <string name="leak_canary_notification_heap_dump_disabled">Heap Dump was not triggered since it is disabled from the About Screen.</string>
   <string name="leak_canary_notification_retained_visible">App visible, waiting until %d retained objects</string>
   <string name="leak_canary_share_with">Share with…</string>
   <string name="leak_canary_display_activity_label">Leaks</string>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -32,7 +32,7 @@
   <string name="leak_canary_heap_dump_not_installed_text">AppWatcher is not installed.</string>
   <string name="leak_canary_heap_dump_enabled_text">Heap dumping is currently enabled.</string>
   <string name="leak_canary_heap_dump_disabled_by_app">LeakCanary.Config.dumpHeap is set to false</string>
-  <string name="leak_canary_heap_dump_disabled_from_ui">Heap dump is disabled from UI</string>
+  <string name="leak_canary_heap_dump_disabled_from_ui">Heap dump is disabled from About Screen</string>
   <string name="leak_canary_heap_dump_disabled_running_tests">tests are running</string>
   <string name="leak_canary_heap_dump_disabled_build_non_debuggable">the debugger is attached and LeakCanary.Config.dumpHeapWhenDebugging is set to false</string>
   <string name="leak_canary_analysis_failed">Heap analysis failed</string>
@@ -57,6 +57,7 @@
   <string name="leak_canary_notification_retained_dump_failed">Failed to dump heap</string>
   <string name="leak_canary_notification_retained_dump_wait">Last heap dump was less than a minute ago</string>
   <string name="leak_canary_notification_retained_title">%d retained objects, tap to dump heap</string>
+  <string name="leak_canary_notification_heap_dump_disabled">Heap Dump is disabled from About Screen</string>
   <string name="leak_canary_notification_retained_visible">App visible, waiting until %d retained objects</string>
   <string name="leak_canary_share_with">Share with…</string>
   <string name="leak_canary_display_activity_label">Leaks</string>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -58,6 +58,7 @@
   <string name="leak_canary_notification_retained_dump_wait">Last heap dump was less than a minute ago</string>
   <string name="leak_canary_notification_retained_title">%d retained objects, tap to dump heap</string>
   <string name="leak_canary_notification_heap_dump_disabled">Heap Dump was not triggered since it is disabled from the About Screen.</string>
+  <string name="leak_canary_notification_heap_dump_tap_to_dismiss">Tap to dismiss</string>
   <string name="leak_canary_notification_retained_visible">App visible, waiting until %d retained objects</string>
   <string name="leak_canary_share_with">Share with…</string>
   <string name="leak_canary_display_activity_label">Leaks</string>


### PR DESCRIPTION

We'd like to add a Switch in the About section that could Enable/Disable heap dump as needed.

| Heap Dump Enabled  	| Heap Dump Disabled   	|
|--------	|---	|
| ![screen](https://user-images.githubusercontent.com/6257696/87873103-51dbc200-c973-11ea-8877-545e2a6fba2c.png)       	| ![screen](https://user-images.githubusercontent.com/6257696/87883050-72c70600-c9b9-11ea-8fa7-ca9c4ccc8a2d.png)  	|


**Notification Mechanism**

![foo511](https://user-images.githubusercontent.com/6257696/87883742-4792e580-c9be-11ea-9d9a-16938e1704b3.gif)
